### PR TITLE
Remove duplicate npm install commands from run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -3,10 +3,6 @@
 echo migrate database...
 python /code/crt_portal/manage.py migrate
 
-echo USWDS gulp commands...
-# running USWDS https://github.com/uswds/uswds-gulp
-npm install autoprefixer css-mqpacker cssnano gulp@^4.0.0 gulp-notify gulp-postcss gulp-rename gulp-replace gulp-sass gulp-sourcemaps path uswds@latest uswds-gulp@github:uswds/uswds-gulp --save-dev
-
 echo Starting Django Server…
 python /code/crt_portal/manage.py compress
 python /code/crt_portal/manage.py runserver 0.0.0.0:8000


### PR DESCRIPTION
@LindsayYoung I noticed the Docker setup scripts run `npm install` in two places: the Dockerfile, which installs from package.json, and `run.sh`, which installs a list of packages. 

Installing from package.json seems like the more idiomatic approach, and the packages from `run.sh` appear to be duplicates. 

I tried a fresh docker compose build/up on this branch and the USWDS styles appear the same on `/form`, so I think we can safely remove these lines from run.sh. 